### PR TITLE
solve issue of low contrast

### DIFF
--- a/res/layout/activity_main.xml
+++ b/res/layout/activity_main.xml
@@ -51,6 +51,7 @@
         
     <Button
         android:id="@+id/btnAbout"
+	android:textColor="#DCDCDC"
         style="?android:attr/buttonStyleSmall"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
The original text color of the component is '#FFFFFF', and the contrast between the text color ('#B3DAEF') and the background color ('#0082C9') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#000000') are as follows:
![image](https://user-images.githubusercontent.com/101503193/167417656-d0f02ced-206f-4386-a31d-a7f04f5c8e14.png)
![image](https://user-images.githubusercontent.com/101503193/167417907-3cf31375-124d-4469-902d-f1a66785fc67.png)

The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.